### PR TITLE
feat: Use more appropriate hardware specific configuration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -144,8 +144,8 @@
           ./nixos/hosts/HGT-H0197-24/configuration.nix
           disko.nixosModules.disko
           lanzaboote.nixosModules.lanzaboote
-          nixos-hardware.nixosModules.lenovo-thinkpad-t14
-          nixos-hardware.nixosModules.common-cpu-intel
+          nixos-hardware.nixosModules.lenovo-thinkpad-t14-intel-gen6
+          { services.fprintd.enable = false; }
           home-manager.nixosModules.home-manager
           {
             home-manager.useGlobalPkgs = true;


### PR DESCRIPTION
- Use nixos-hardware's gen6 specific t14 config instead of a more generic t14 config. Among other things, this uses the intel graphics `xe` driver instead of the `i915` driver, which hopefully resolves some graphics issues.

- Disables finger print reader enabled by t14-intel-gen6 config to avoid login issues. See https://github.com/NixOS/nixos-hardware/blob/master/lenovo/thinkpad/t14/intel/gen6/default.nix for details.